### PR TITLE
Add `@public`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ Decentralizing exports in Julia
 
 ## Usage
 
-`InlineExports` provides the convenience macro, `@export`, for
-exporting names in a module at the location of definition, as an
-alternative to the convention of exporting names at the top of the
-module.  `@export` analyses an expression for definitions of
-variables, functions or types, and inserts an appropriate `export`
-statement above.  This is illustrated by the following example:
+`InlineExports` provides two convenience macros, `@export` and
+`@public`.  The first exports names in a module at the location of
+definition, as an alternative to the convention of exporting names at
+the top of the module.  `@export` analyses an expression for
+definitions of variables, functions or types, and inserts an
+appropriate `export` statement above.  On Julia 1.11 and later,
+`@public` does essentially the same thing, except that it inserts
+`public` statements; on earlier versions, it does nothing.
+
+This is illustrated by the following example:
 
 ```julia
 module M
@@ -36,12 +40,23 @@ end
     ...
 end
 
+"""
+    h(x)
+
+...
+"""
+@public function h(x)
+    ...
+end
+
 end
 ```
 
-The module above will export the names `T` and `g`.  Alternatively,
-definitions can be wrapped inside a block.  The example below will
-export both `a`, `b` and `c`:
+The module above will export the names `T` and `g`, but not `f` or `h`
+— though `h` will be marked as `public` on Julia 1.11 and later.
+Alternatively, definitions can be wrapped inside a block.  The example
+below will export `a`, `b` and `c`, but only mark as `public` the
+names `f`, `g` and `h`:
 
 ```julia
 module M
@@ -54,12 +69,18 @@ using InlineExports
     c = 3
 end
 
+@public begin
+    f = 4
+    const g = 5
+    h = 6
+end
+
 end
 ```
 
 ## Disabling inline exports
 
-If you wish to disable all inline exports without removing all `@export` macro calls, `InlineExports` provides a convenience submodule, `InlineExports.NoExport`.  This submodule exports a definition of the `@export` macro which returns the expression untouched.  As an example, this module does not export the function `f(x)`:
+If you wish to disable all inline exports without removing all `@export` or `@public` macro calls, `InlineExports` provides a convenience submodule, `InlineExports.NoExport`.  This submodule exports a definition of the `@export` macro which returns the expression untouched.  As an example, this module does not export the function `f(x)`:
 ```julia
 module M
 
@@ -67,6 +88,11 @@ using InlineExports.NoExport
 
 # Export statements have been disabled.  This function will not be exported
 @export function f(x)
+    ...
+end
+
+# Public markings have been disabled.  This function will not be marked as public
+@public function g(x)
     ...
 end
 

--- a/src/InlineExports.jl
+++ b/src/InlineExports.jl
@@ -100,6 +100,15 @@ handle(::Union{Val{:abstract}, Val{:primitive}}, expr) = handle(expr.args[1])
 handle(::Val{:<:}, expr) = handle(expr.args[1])
 handle(::Val{:curly}, expr) = handle(expr.args[1])
 handle(::Val{:call}, expr) = handle(expr.args[1])
-handle(::Val{:macrocall}, expr) = filter(x -> x !== nothing, map(handle, expr.args[3:end]))
+function handle(::Val{:macrocall}, expr)
+    if expr.args[1]==Symbol("@doc") || (expr.args[1] == Core.GlobalRef(Core, Symbol("@doc")))
+        if length(expr.args) != 4
+            error("@doc expression found with $(length(expr.args)) args:\n$expr")
+        end
+        handle(expr.args[4])
+    else
+        filter(x -> x !== nothing, map(handle, expr.args[3:end]))
+    end
+end
 
 end # module

--- a/src/InlineExports.jl
+++ b/src/InlineExports.jl
@@ -2,7 +2,9 @@ module InlineExports
 
 import Base: @__doc__
 
-export @export
+include("NoExport.jl")
+
+export @export, @public
 
 quote
     """
@@ -31,20 +33,55 @@ quote
     ```
     """
     macro $(Symbol("export"))(expr::Expr)
-        r = handle(expr)
-        if r isa Symbol
-            return quote
-                export $(esc(r))
-                @__doc__ $(esc(expr))
-            end
-        else
-            return quote
-                export $(map(esc, r)...)
-                @__doc__ $(esc(expr))
-            end
-        end
+        return handle(expr, :export)
     end
 end |> eval
+
+if VERSION < v"1.11"
+    using .NoExport: @public
+else
+    """
+        @public
+
+    Return the expression with all bindings marked as public.
+
+    ```
+    julia> module M
+               using InlineExports
+               @public begin
+                   const a = 2
+                   abstract type S <: Number end
+                   struct T <: S
+                       val
+                   end
+               end
+               @public f(x::TT) where {TT<:S} = x.val^2
+           end
+    M
+
+    julia> using .M
+
+    julia> M.f(M.T(M.a))
+    4
+    ```
+    """
+    macro public(expr::Expr)
+        return handle(expr, :public)
+    end
+end
+
+function handle(expr::Expr, export_or_public::Symbol)
+    r = handle(expr)
+    ep = if r isa Symbol
+        Expr(export_or_public, r)
+    else
+        Expr(export_or_public, r...)
+    end
+    return esc(quote
+        $ep
+        Base.@__doc__ $expr
+    end)
+end
 
 handle(::Any) = nothing
 handle(x::Symbol) = x
@@ -64,7 +101,5 @@ handle(::Val{:<:}, expr) = handle(expr.args[1])
 handle(::Val{:curly}, expr) = handle(expr.args[1])
 handle(::Val{:call}, expr) = handle(expr.args[1])
 handle(::Val{:macrocall}, expr) = filter(x -> x !== nothing, map(handle, expr.args[3:end]))
-
-include("NoExport.jl")
 
 end # module

--- a/src/NoExport.jl
+++ b/src/NoExport.jl
@@ -2,7 +2,7 @@ module NoExport
 
 import Base: @__doc__
 
-export @export
+export @export, @public
 
 quote
     """
@@ -14,5 +14,14 @@ quote
         return esc(expr)
     end
 end |> eval
+
+"""
+    @public
+
+No-op.  Used to disable inline public macro.
+"""
+macro public(expr::Expr)
+    return esc(expr)
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,9 @@ using InlineExports
 @export begin
     M2f(a) = a^2
     M2a = 2
+    "docstring M2b"
     const M2b = 3.0
+    @doc raw"docstring M2c ``\alpha``"
     M2c = 7im
 end
 
@@ -51,7 +53,7 @@ end
 @export function M2h end
 
 @doc raw"""
-    docstring ``\alpha``
+    docstring ``\beta``
 """
 @export function M2k end
 
@@ -66,6 +68,8 @@ using .M2
     @test M2f(M2t) == M2f(M2a)
     @test M2g(M2tp) == M2f(M2c)
     if VERSION >= v"1.11"
+        @test Base.Docs.hasdoc(M2, :M2b)
+        @test Base.Docs.hasdoc(M2, :M2c)
         @test Base.Docs.hasdoc(M2, :M2h)
         @test Base.Docs.hasdoc(M2, :M2k)
     end
@@ -91,7 +95,9 @@ using InlineExports
 @public begin
     M4f(a) = a^2
     M4a = 2
+    "docstring M2b"
     const M4b = 3.0
+    @doc raw"docstring M4c ``\alpha``"
     M4c = 7im
 end
 
@@ -168,6 +174,8 @@ using .M4
         @test Base.ispublic(M4, :M4T)
         @test Base.ispublic(M4, :M4TP)
         @test Base.ispublic(M4, Symbol("@M4macro"))
+        @test Base.Docs.hasdoc(M4, :M4b)
+        @test Base.Docs.hasdoc(M4, :M4c)
         @test Base.Docs.hasdoc(M4, :M4h)
         @test Base.Docs.hasdoc(M4, :M4k)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,11 @@ end
 """
 @export function M2h end
 
+@doc raw"""
+    docstring ``\alpha``
+"""
+@export function M2k end
+
 end
 
 using .M2
@@ -60,11 +65,16 @@ using .M2
     @test M2f(M2c) == -49
     @test M2f(M2t) == M2f(M2a)
     @test M2g(M2tp) == M2f(M2c)
+    if VERSION >= v"1.11"
+        @test Base.Docs.hasdoc(M2, :M2h)
+        @test Base.Docs.hasdoc(M2, :M2k)
+    end
 end
 
 module M3
 using InlineExports.NoExport
 @export M3f() = 42
+@public M3g() = 27
 end
 
 using .M3
@@ -72,6 +82,95 @@ using .M3
 @testset "NoExport" begin
     @test_throws UndefVarError M3f()
     @test M3.M3f() === 42
+    @test_throws UndefVarError M3g()
+    @test M3.M3g() === 27
+end
+
+module M4
+using InlineExports
+@public begin
+    M4f(a) = a^2
+    M4a = 2
+    const M4b = 3.0
+    M4c = 7im
+end
+
+@public abstract type M4S{T} <: Number end
+@public primitive type M4P <: Number 8 end
+@public macro M4macro(expr)
+    expr
+end
+
+@public struct M4TP{T} <: M4S{T}
+    val::T
+end
+
+@public struct M4T <: M4S{Number}
+    val::Number
+end
+
+@public @inline M4f(a::M4T) = M4f(a.val)
+
+@public function M4g(a::M4TP{T}) where {T<:Number}
+    return convert(T, M4f(a.val))
+end
+
+@public M4t = M4T(M4a)
+@public M4tp = M4TP(M4c)
+
+"""
+    docstring
+"""
+@public function M4h end
+
+@doc raw"""
+    docstring ``\alpha``
+"""
+@public function M4k end
+
+end
+
+using .M4
+
+@testset "Public" begin
+    @test M4.M4f(M4.M4a) == 4
+    @test M4.M4f(M4.M4b) == 9.0
+    @test M4.M4f(M4.M4c) == -49
+    @test M4.M4f(M4.M4t) == M4.M4f(M4.M4a)
+    @test M4.M4g(M4.M4tp) == M4.M4f(M4.M4c)
+
+    @test_throws UndefVarError M4a
+    @test_throws UndefVarError M4b
+    @test_throws UndefVarError M4c
+    @test_throws UndefVarError M4f()
+    @test_throws UndefVarError M4g()
+    @test_throws UndefVarError M4h()
+    @test_throws UndefVarError M4k()
+    @test_throws UndefVarError M4t
+    @test_throws UndefVarError M4tp
+    @test_throws UndefVarError M4P
+    @test_throws UndefVarError M4S
+    @test_throws UndefVarError M4T
+    @test_throws UndefVarError M4TP
+
+    if VERSION >= v"1.11"
+        @test Base.ispublic(M4, :M4a)
+        @test Base.ispublic(M4, :M4b)
+        @test Base.ispublic(M4, :M4c)
+        @test Base.ispublic(M4, :M4f)
+        @test Base.ispublic(M4, :M4g)
+        @test Base.ispublic(M4, :M4h)
+        @test Base.ispublic(M4, :M4k)
+        @test Base.ispublic(M4, :M4t)
+        @test Base.ispublic(M4, :M4tp)
+        @test Base.ispublic(M4, :M4P)
+        @test Base.ispublic(M4, :M4S)
+        @test Base.ispublic(M4, :M4T)
+        @test Base.ispublic(M4, :M4TP)
+        @test Base.ispublic(M4, Symbol("@M4macro"))
+        @test Base.Docs.hasdoc(M4, :M4h)
+        @test Base.Docs.hasdoc(M4, :M4k)
+    end
 end
 
 end #module


### PR DESCRIPTION
Julia 1.11's `public` keyword functions much the same as `export`, so I think it makes sense to have the corresponding `@public` macro in this package.

Here's the summary of things I've done:

1. Moved the processing out of `@export` into new method `handle(::Expr,::Symbol)`.
2. Created `@public`
3. Created the no-op version: `NoExport.@public`
4. Moved `include("NoExport.jl")` to the top of the main file, which enables...
5. Used the no-op version of `@public` on older Julia versions.
6. Tested on fixed `handle(::Val{:macrocall}, expr)` to deal with expressions inside blocks with docstrings
7. Described `@public` in the README.
8. Added lots of tests, including tests that use Julia>=1.11 capabilities.
9. Ran the test suite (all tests passed) on Julia versions I happened to have installed:
    - 1.0 (which required removing the Manifest.toml)
    - 1.7
    - 1.8
    - 1.9
    - 1.10
    - 1.11
    - 1.12.0-beta3

Note that item 5 has the nice feature of letting us use `@public`, even for code that will run on the old versions of Julia.